### PR TITLE
Excluding files/directories starting with "." from zipped source

### DIFF
--- a/devtools/scripts/checkAddOn.groovy
+++ b/devtools/scripts/checkAddOn.groovy
@@ -542,7 +542,9 @@ if (node.map.file != null) {
         }
         zipsDir.eachFileRecurse(FileType.FILES) { file ->
             def fileName = file.path.substring(zipsDir.path.length() + 1)
-            filesToUninstall << fileName
+            if (!(fileName =~ /\\\./)) {
+            	filesToUninstall << fileName
+            }
         }
     }
 }

--- a/devtools/scripts/releaseAddOn.groovy
+++ b/devtools/scripts/releaseAddOn.groovy
@@ -161,16 +161,18 @@ byte[] getZipBytes(File topDir) {
 		if (file.isDirectory() && !relative.endsWith('/')){
 			relative += "/"
 		}
-		println "adding $relative"
-		ZipEntry entry = new ZipEntry(relative)
-		entry.time = file.lastModified()
-		zipOutput.putNextEntry(entry)
-		if (file.isFile()) {
-            def fileInputStream = new FileInputStream(file)
-            zipOutput << fileInputStream
-            fileInputStream.close()
+		if (!(relative =~ /\/\./)) {
+			println "adding $relative"
+			ZipEntry entry = new ZipEntry(relative)
+			entry.time = file.lastModified()
+			zipOutput.putNextEntry(entry)
+			if (file.isFile()) {
+				def fileInputStream = new FileInputStream(file)
+				zipOutput << fileInputStream
+				fileInputStream.close()
+			}
+			++filesAdded
 		}
-        ++filesAdded
 	}
     if (filesAdded) {
         zipOutput.close()


### PR DESCRIPTION
Hello Volker,

My main purpose of this pull request is to find out how to use a pull request.

My use case is as follows. The Eclipse project for my add-on's lib .jar file is situated in the following directory, relative to my add-on's .mm file:
zips/src
In this way I can zip the source directly into the add-on. But I do not want to include the Eclipse files/directories .classpath, .project and .settings. I also want to exclude the compiled classes from being zipped.

The changes in this pull request exclude files starting with "." or in directories starting with "." from being zipped.

By choosing a Eclipse default output folder starting with ".", e.g. ".bin", compiled classes will also be excluded.

By the way, I wrote about this in https://sourceforge.net/p/freeplane/featurerequests/2161/ and saw that you actually applied the file filter for the directory scripts.

Best regards,

Henk