### PR TITLE
Fix bug #2642 Devtools creates wrong menuTitleKey for scripts

### DIFF
--- a/devtools/scripts/checkAddOn.groovy
+++ b/devtools/scripts/checkAddOn.groovy
@@ -437,7 +437,7 @@ if (scriptsNodesWithUnknownSuffixes) {
 
 scriptsNode.children.each {
     def scriptBaseName = it.plainText.replaceFirst('\\.\\w+$', '')
-    def menuTitleKey = "addon.\${name}.${scriptBaseName}"
+    def menuTitleKey = "addons.\${name}.${scriptBaseName}"
     createMissingAttributes(it, [
         [ 'menuTitleKey', menuTitleKey ]
         , ['menuLocation', 'main_menu_scripting']


### PR DESCRIPTION
The devtools script `checkAddOn.groovy` adds
`addon.${name}.<scriptname>` as `menuTitleKey` to the script nodes.
According to the note of the translation node this should be
`addons.${name}.<scriptname>`. In addition `checkAddOn.groovy` adds the
add-on name to the translation keys as `addons.${name}`.

To fix this line 440 of checkAddOn.groovy should be changed from:

`def menuTitleKey = "addon.\${name}.${scriptBaseName}"`

to:

`def menuTitleKey = "addons.\${name}.${scriptBaseName}"`

https://sourceforge.net/p/freeplane/bugs/2642/