### PR TITLE
Feature request #2464 Devtools: name of add-on as submenu of Tools

### DIFF
--- a/devtools/scripts/checkAddOn.groovy
+++ b/devtools/scripts/checkAddOn.groovy
@@ -440,7 +440,7 @@ scriptsNode.children.each {
     def menuTitleKey = "addons.\${name}.${scriptBaseName}"
     createMissingAttributes(it, [
         [ 'menuTitleKey', menuTitleKey ]
-        , ['menuLocation', 'main_menu_scripting']
+        , ['menuLocation', 'main_menu_scripting/addons.\${name}']
         , ['executionMode', 'on_single_node']
         , 'keyboardShortcut'
         , ['execute_scripts_without_asking', 'true']


### PR DESCRIPTION
If you create a new add-on with devtools script `checkAddOn.groovy` and
you do not change `menuLocation`, the menu items for the add-on scripts
will be direct under 'Tools'.

I think it would be nicer if checkAddOn.groovy would be implementing the
following default: the menu items for the add-on scripts are located
under a sub-menu under 'Tools' with the name of the add-on.

I have achieved this by changing line 443 in checkAddOn.groovy from:

        , ['menuLocation', 'main_menu_scripting']

to:

        , ['menuLocation', 'main_menu_scripting/addon.${name}']

Advantages:

* By default a neater organisation of multiple add-ons with multiple
scripts under the 'Tools' menu.
* It demonstrates to the developer how a submenu with translation key
can be created.

Disadvantage:

* It might be confusing for an add-on developer who adds a script to an
existing add-on

https://sourceforge.net/p/freeplane/featurerequests/2464/