### PR TITLE
Bug #2847: Devtools/Gradle plugin incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 *-v[0-9]*.mm
 *.bak
+.classpath
+.gitignore
+.gradle
+.groovy
+.project
+.settings
 addons.zip
 bin
+commitmessage.txt
 packAndGo/*.zip
 packAndGo/test/zipMap.zip
-.groovy
 version.properties
-.settings/org.eclipse.jdt.groovy.core.prefs

--- a/devtools/devtools.mm
+++ b/devtools/devtools.mm
@@ -1,9 +1,9 @@
 <map version="freeplane 1.8.0">
 <!--To view this file, download free mind mapping software Freeplane from http://freeplane.sourceforge.net -->
-<node TEXT="Developer Tools" FOLDED="false" ID="ID_1723255651" CREATED="1283093380553" MODIFIED="1548536233412" LINK="https://sourceforge.net/projects/freeplane/files/addons/devtools" BACKGROUND_COLOR="#97c7dc">
+<node TEXT="Developer Tools" FOLDED="false" ID="ID_1723255651" CREATED="1283093380553" MODIFIED="1607295697632" LINK="https://sourceforge.net/projects/freeplane/files/addons/devtools" BACKGROUND_COLOR="#97c7dc">
 <font SIZE="16" BOLD="true" ITALIC="true"/>
 <hook NAME="MapStyle">
-    <properties show_icon_for_attributes="true" fit_to_viewport="false" show_note_icons="true"/>
+    <properties show_icon_for_attributes="true" show_note_icons="true" fit_to_viewport="false"/>
 
 <map_styles>
 <stylenode LOCALIZED_TEXT="styles.root_node" STYLE="oval" UNIFORM_SHAPE="true" VGAP_QUANTITY="24.0 pt">
@@ -117,9 +117,9 @@
 </hook>
 <attribute_layout NAME_WIDTH="95.99999713897714 pt" VALUE_WIDTH="95.99999713897714 pt"/>
 <attribute NAME="name" VALUE="devtools"/>
-<attribute NAME="version" VALUE="v0.9.26"/>
+<attribute NAME="version" VALUE="v0.9.27"/>
 <attribute NAME="author" VALUE="Volker Börchers"/>
-<attribute NAME="freeplaneVersionFrom" VALUE="v1.7.4"/>
+<attribute NAME="freeplaneVersionFrom" VALUE="v1.8.0"/>
 <attribute NAME="freeplaneVersionTo" VALUE=""/>
 <attribute NAME="updateUrl" VALUE=""/>
 <richcontent TYPE="NOTE">
@@ -575,6 +575,7 @@
 <node TEXT="checkAddOn.groovy checks the name of the script too" ID="ID_1103423593" CREATED="1352597072965" MODIFIED="1352597097582"/>
 </node>
 <node TEXT="v0.9.14" FOLDED="true" ID="ID_1988499160" CREATED="1378242261572" MODIFIED="1378242270008">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
 <node TEXT="update for multiple scripting languages" ID="ID_1961614140" CREATED="1378242272415" MODIFIED="1378242296802"/>
 <node TEXT="support for updateUrl" ID="ID_563212535" CREATED="1378242297556" MODIFIED="1378242306047"/>
 </node>
@@ -624,12 +625,25 @@
 </node>
 <node TEXT="v0.9.25" FOLDED="true" ID="ID_1823309527" CREATED="1545222338001" MODIFIED="1548536445091">
 <attribute_layout VALUE_WIDTH="100.0 pt"/>
-<node TEXT="#2643 Devtools does not display its add-on name in menu" ID="ID_1184303114" CREATED="1548536744615" MODIFIED="1548536766123"/>
-<node TEXT="#2464 test for missing English translations for scripts" ID="ID_1596709901" CREATED="1548536589892" MODIFIED="1548536627896"/>
+<node TEXT="#2643 Devtools does not display its add-on name in menu" ID="ID_1184303114" CREATED="1548536744615" MODIFIED="1548536766123">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+</node>
+<node TEXT="#2464 test for missing English translations for scripts" ID="ID_1596709901" CREATED="1548536589892" MODIFIED="1548536627896">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+</node>
 <node TEXT="Set icon for devtools sub menu" ID="ID_265129237" CREATED="1548533999679" MODIFIED="1548534026969"/>
 </node>
 <node TEXT="v0.9.26" FOLDED="true" ID="ID_497897109" CREATED="1593032987738" MODIFIED="1593032997005">
-<node TEXT="Fix for #2798 : Menu Item Info error" ID="ID_1640195555" CREATED="1593033040682" MODIFIED="1593033857920"/>
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+<node TEXT="Fix for #2798 : Menu Item Info error" ID="ID_1640195555" CREATED="1593033040682" MODIFIED="1593033857920">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+</node>
+</node>
+<node TEXT="v0.9.27" FOLDED="true" ID="ID_910769393" CREATED="1607295745747" MODIFIED="1607295766659">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+<node TEXT="#2847 Devtools&apos; checkAddOn.groovy not compatible with Gradle plugin&apos;s directory structure" ID="ID_843234771" CREATED="1607295846781" MODIFIED="1607295853152">
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
+</node>
 </node>
 </node>
 <node TEXT="license" FOLDED="true" POSITION="left" ID="ID_770036552" CREATED="1319814596814" MODIFIED="1548535421625"><richcontent TYPE="NOTE">
@@ -651,6 +665,7 @@
   </body>
 </html>
 </richcontent>
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
 <node TEXT="This add-on is free software: you can redistribute it and/or modify&#xa;it under the terms of the GNU General Public License as published by&#xa;the Free Software Foundation, either version 2 of the License, or&#xa;(at your option) any later version.&#xa;&#xa;This program is distributed in the hope that it will be useful,&#xa;but WITHOUT ANY WARRANTY; without even the implied warranty of&#xa;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#xa;GNU General Public License for more details." ID="ID_1912443753" CREATED="1319814828201" MODIFIED="1319814831174"/>
 </node>
 <node TEXT="preferences.xml" POSITION="left" ID="ID_1267015903" CREATED="1313132482700" MODIFIED="1548535421628"><richcontent TYPE="NOTE">
@@ -669,6 +684,7 @@
   </body>
 </html>
 </richcontent>
+<attribute_layout VALUE_WIDTH="100.0 pt"/>
 </node>
 <node TEXT="default.properties" POSITION="left" ID="ID_1363888784" CREATED="1313132482695" MODIFIED="1548535421630">
 <attribute_layout NAME_WIDTH="138.74999586492788 pt" VALUE_WIDTH="138.74999586492788 pt"/>

--- a/devtools/scripts/checkAddOn.groovy
+++ b/devtools/scripts/checkAddOn.groovy
@@ -421,9 +421,13 @@ if (node.map.file != null) {
     def scriptsDirs = []
     scriptsDirs << new File(node.map.file.parent, 'scripts')
     // includes scripts locations in case of Gradle plugin
-    if (node.map.file.parentFile.parentFile.name == 'src') {
-        scriptsDirs << new File(node.map.file.parentFile.parent, 'scripts')
-    }
+	try {
+	    if (node.map.file.parentFile.parentFile.name == 'src') {
+	        scriptsDirs << new File(node.map.file.parentFile.parent, 'scripts')
+	    }
+	} catch (Exception e) {
+		logger.warn('Why do you store your add-on definition mind map in a root directory?\n', e)
+	}
     scriptsDirs.each {
         if (it.exists()) {
             it.eachFileRecurse(FileType.FILES) { file ->

--- a/devtools/scripts/checkAddOn.groovy
+++ b/devtools/scripts/checkAddOn.groovy
@@ -417,15 +417,22 @@ scriptsNode.note = withBody '''
     </p>
 '''
 if (node.map.file != null) {
-    def filesToExclude = ['.classpath', '.project', 'freeplane.dsld']
-    def scriptsDir = new File(node.map.file.parent, 'scripts')
-    if (scriptsDir.exists()) {
-        scriptsDir.eachFile(FileType.FILES) { file ->
-            def fileName = file.name
-            if (filesToExclude.indexOf(fileName) == -1
-                && scriptsNode.children.find { it.text.contains(fileName) } == null)
-            {
-                scriptsNode.createChild(fileName)
+    def filesToExclude = ['.classpath', '.project', 'freeplane.dsld', 'freeplane.gdsl']
+    def scriptsDirs = []
+    scriptsDirs << new File(node.map.file.parent, 'scripts')
+    // includes scripts locations in case of Gradle plugin
+    if (node.map.file.parentFile.parentFile.name == 'src') {
+        scriptsDirs << new File(node.map.file.parentFile.parent, 'scripts')
+    }
+    scriptsDirs.each {
+        if (it.exists()) {
+            it.eachFileRecurse(FileType.FILES) { file ->
+                def fileName = file.name
+                if (filesToExclude.indexOf(fileName) == -1
+                    && scriptsNode.children.find { it.text.contains(fileName) } == null)
+                {
+                    scriptsNode.createChild(fileName)
+                }
             }
         }
     }


### PR DESCRIPTION
https://sourceforge.net/p/freeplane/bugs/2847/
Devtools' checkAddOn.groovy not compatible with
Gradle plugin's directory structure

Devtools' Build add-on function
(checkAddOn.groovy) will now also add script nodes
for scripts that are kept in the Gradle plugin
scripts folder. It does this in addition to the
original functionality: adding script nodes from
the scrips folder relative to the add-on
definition mind map. This means this functionality
will now work when using Devtools standalone and
in combination with the Gradle plugin.

Applied changes

Exclude file name freeplane.gdsl from making
script nodes (like file name freeplane.dsld).

Only look for scripts on the Gradle plugin
location if this plugin is used. In that case
'src' should be the name of the directory one
level higher than the directory of add-on
definition mind map. If the location of this mind
map is customized in build.gradle the name of this
directory might differ. In that case it is not
possible to determine the location of Gradle
plugin scripts and the Build add-on funcion will
fail any way.

Include all file names in sub directories of
src/scripts when making script nodes. The official
directory is src/scripts/groovy. However freeplane
also allows JavaScript and, if you include an
interpreter library, also other scripting
languages. It is not sure whether the Gradle
plugin supports other scripting languages now, but
in this way this fix prepares for the future.